### PR TITLE
More big-O notation puns

### DIFF
--- a/o.js
+++ b/o.js
@@ -6,7 +6,8 @@ import './src/maybe-lockdown.js';
 import { makeHeapZone } from '@agoric/base-zone/heap.js';
 import { prepareOTools } from './src/endo-o.js';
 
-const { makeO } = prepareOTools(makeHeapZone());
+const oZone = makeHeapZone();
+const { makeO } = prepareOTools(oZone);
 
 const O = makeO({
   help: 'This is a help message',


### PR DESCRIPTION
This pull request includes a minor change to the initialization of the `makeO` function in the `o.js` file. The change separates the creation of the `oZone` from the preparation of tools.

* [`o.js`](diffhunk://#diff-246877dc99213d2a32c751206273c35b407b7411f424b13944a4f30e6025ccf1L9-R10): Changed the initialization of `makeO` by creating `oZone` separately before passing it to `prepareOTools`.